### PR TITLE
Remove the no-arguments tests

### DIFF
--- a/main.js
+++ b/main.js
@@ -773,7 +773,7 @@ async function main() {
   const token = process.env.GITHUB_TOKEN;
   const args = process.argv.slice(2);
 
-  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+  if (args.includes("--help") || args.includes("-h")) {
     showHelp();
   }
 


### PR DESCRIPTION
I made a silly vibe-coding mistake last time in #2 that is now preventing the ability to run the script in the default mode (by `npm start`), making the script always show the help message instead.

This quick PR fixes that.

